### PR TITLE
Fixes #7 incorrect bit mask in DOS date/time decoding

### DIFF
--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/util/LocalDateTimeExtensions.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/util/LocalDateTimeExtensions.kt
@@ -24,32 +24,32 @@ import kotlinx.datetime.number
 
 @InternalCompressionApi
 fun UShort.unpackTimeWord(): LocalTime {
-    val hours = ((toUInt() shr 11) and 0b1111U).toInt()
-    val minutes = ((toUInt() shr 5) and 0b1111U).toInt()
-    val seconds = ((toUInt() and 0b1111U) shl 1).toInt()
+    val hours = ((toUInt() shr 11) and 0b11111U).toInt()
+    val minutes = ((toUInt() shr 5) and 0b111111U).toInt()
+    val seconds = ((toUInt() and 0b11111U) shl 1).toInt()
     return LocalTime(hours, minutes, seconds)
 }
 
 @InternalCompressionApi
 fun UShort.unpackDateWord(): LocalDate {
-    val year = (((toUInt() shr 9) and 0b111111U) + 1980U).toInt()
-    val month = ((toUInt() shr 5) and 0b111U).toInt()
-    val day = (toUInt() and 0b1111U).toInt()
+    val year = (((toUInt() shr 9) and 0b1111111U) + 1980U).toInt()
+    val month = ((toUInt() shr 5) and 0b1111U).toInt()
+    val day = (toUInt() and 0b11111U).toInt()
     return LocalDate(year, month, day)
 }
 
 @InternalCompressionApi
 fun LocalDateTime.packTimeWord(): UShort {
-    val hours = (hour and 0b1111).toUInt()
-    val minutes = (minute and 0b1111).toUInt()
-    val seconds = ((second shr 1) and 0b1111).toUInt()
+    val hours = (hour and 0b11111).toUInt()
+    val minutes = (minute and 0b111111).toUInt()
+    val seconds = ((second shr 1) and 0b11111).toUInt()
     return ((hours shl 11) or (minutes shl 5) or seconds).toUShort()
 }
 
 @InternalCompressionApi
 fun LocalDateTime.packDateWord(): UShort {
-    val year = ((year - 1980) and 0b111111).toUInt()
-    val month = (month.number and 0b111).toUInt()
-    val day = (day and 0b1111).toUInt()
+    val year = ((year - 1980) and 0b1111111).toUInt()
+    val month = (month.number and 0b1111).toUInt()
+    val day = (day and 0b11111).toUInt()
     return ((year shl 9) or (month shl 5) or day).toUShort()
 }

--- a/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/util/LocalDateTimeExtensionsTest.kt
+++ b/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/util/LocalDateTimeExtensionsTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.util
+
+import dev.karmakrafts.kompress.InternalCompressionApi
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.atTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(InternalCompressionApi::class)
+class LocalDateTimeExtensionsTest {
+    @Test
+    fun testPackLowDateTime() {
+        val localDateTime = LocalDate(1980, 1, 1).atTime(0, 0, 0)
+        val packedDate = localDateTime.packDateWord()
+        val packedTime = localDateTime.packTimeWord()
+        assertEquals(packedDate, 33.toUShort())
+        assertEquals(packedTime, 0.toUShort())
+    }
+
+    @Test
+    fun testPackAndUnpackLowDate() {
+        val date = LocalDate(1980, 1, 1)
+        val time = LocalTime(0, 0, 0)
+        val localDateTime = date.atTime(time)
+        val packedDate = localDateTime.packDateWord()
+        assertEquals(date, packedDate.unpackDateWord())
+    }
+
+    @Test
+    fun testPackAndUnpackLowTime() {
+        val date = LocalDate(1980, 1, 1)
+        val time = LocalTime(0, 0, 0)
+        val localDateTime = date.atTime(time)
+        val packedTime = localDateTime.packTimeWord()
+        assertEquals(time, packedTime.unpackTimeWord())
+    }
+
+    @Test
+    fun testPackAndUnpackHighDate() {
+        val date = LocalDate(2099, 12, 31)
+        val time = LocalTime(0, 0, 0)
+        val localDateTime = date.atTime(time)
+        val packedDate = localDateTime.packDateWord()
+        assertEquals(date, packedDate.unpackDateWord())
+    }
+
+    @Test
+    fun testPackAndUnpackHighTime() {
+        val date = LocalDate(1980, 1, 1)
+        val time = LocalTime(23, 59, 58)
+        val localDateTime = date.atTime(time)
+        val packedTime = localDateTime.packTimeWord()
+        assertEquals(time, packedTime.unpackTimeWord())
+    }
+}


### PR DESCRIPTION
The bit masks in `(un)pack(Date|Time)Word` were too short, causing errors for months >= 8, days >= 16, etcetera. This PR adds a few tests reproducing the failure and extends the bit masks.