### PR TITLE
Fix/huffman code length limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- `Deflater` emitting streams that could not be read back when Huffman code lengths exceeded the 15 bits RFC1951 allows, which affected sufficiently large or skewed inputs
+
 ## [2.3.1]
 
 ### Fixed

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/DeflateConstants.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/DeflateConstants.kt
@@ -40,6 +40,9 @@ internal object DeflateConstants {
     const val MAX_CODE_LENGTH: Int = 15
     const val CL_CODE_LENGTH_SIZE: Int = 3
 
+    /** Code-length codes are written as [CL_CODE_LENGTH_SIZE] bit values, so they cannot exceed this. */
+    const val MAX_CL_CODE_LENGTH: Int = (1 shl CL_CODE_LENGTH_SIZE) - 1
+
     const val BTYPE_SIZE: Int = 2
     const val BTYPE_STORED: ULong = 0b00UL
     const val BTYPE_STATIC: ULong = 0b01UL

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/DeflateConstants.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/DeflateConstants.kt
@@ -16,6 +16,8 @@
 
 package dev.karmakrafts.kompress.deflate
 
+import dev.karmakrafts.kompress.huffman.HuffmanTree
+
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -37,7 +39,7 @@ internal object DeflateConstants {
     const val DISTANCE_ALPHABET_SIZE: Int = 30
     const val CODE_LENGTH_ALPHABET_SIZE: Int = 19
 
-    const val MAX_CODE_LENGTH: Int = 15
+    const val MAX_CODE_LENGTH: Int = HuffmanTree.MAX_CODE_LENGTH
     const val CL_CODE_LENGTH_SIZE: Int = 3
 
     /** Code-length codes are written as [CL_CODE_LENGTH_SIZE] bit values, so they cannot exceed this. */

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/Deflater.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/Deflater.kt
@@ -284,7 +284,8 @@ internal class DeflaterImpl( // @formatter:off
         collectDynamicTreeSymbols(distanceLengths, distanceCodesCount)
 
         // RFC1951 3.2.7: derive the code-length tree from frequencies of lengths and repeat symbols.
-        val lengthTree = HuffmanTree.fromFrequencies(lengthFrequencies)
+        // Its own code lengths ship as three bit values, so they are capped tighter than the rest.
+        val lengthTree = HuffmanTree.fromFrequencies(lengthFrequencies, DeflateConstants.MAX_CL_CODE_LENGTH)
         val lengthTreeLengths = lengthTree.codeLengths()
         // RFC1951 3.2.7: HCLEN stores the number of code-length codes minus four.
         val codeLengthCodesCount = computeCodeLengthCodesCount(lengthTreeLengths)

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
@@ -82,8 +82,16 @@ internal class HuffmanTree(
         private const val LENGTH_BITS: Int = 4
         private const val LENGTH_MASK: Int = (1 shl LENGTH_BITS) - 1
 
-        /** The longest code RFC1951 permits, which is also all the packed representation can hold. */
-        const val MAX_CODE_LENGTH: Int = LENGTH_MASK
+        /** The longest codeword RFC1951 3.2.7 permits. */
+        const val MAX_CODE_LENGTH: Int = 15
+
+        init {
+            // The packed representation stores the length in LENGTH_BITS bits. Widening the RFC
+            // limit without widening the packing would silently truncate lengths.
+            check(MAX_CODE_LENGTH <= LENGTH_MASK) {
+                "MAX_CODE_LENGTH $MAX_CODE_LENGTH does not fit in $LENGTH_BITS bits"
+            }
+        }
 
         fun packSymbol(symbol: Int, length: Int): Int = (symbol shl LENGTH_BITS) or length
 
@@ -125,7 +133,10 @@ internal class HuffmanTree(
             while (kraft > scale) {
                 var bits = maxCodeLength - 1
                 while (bits > 0 && counts[bits] == 0) bits--
-                if (bits == 0) break // Unreachable: an over-subscribed tree always has a short code.
+                // Only reachable if the alphabet cannot fit under maxCodeLength at all, which would
+                // mean more than 2^maxCodeLength used symbols. Failing here beats handing back an
+                // over-subscribed tree that corrupts the decode table later.
+                check(bits > 0) { "Cannot fit alphabet into $maxCodeLength bit codes" }
                 counts[bits]--
                 counts[bits + 1]++
                 kraft -= 1L shl (maxCodeLength - bits - 1)

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
@@ -82,13 +82,81 @@ internal class HuffmanTree(
         private const val LENGTH_BITS: Int = 4
         private const val LENGTH_MASK: Int = (1 shl LENGTH_BITS) - 1
 
+        /** The longest code RFC1951 permits, which is also all the packed representation can hold. */
+        const val MAX_CODE_LENGTH: Int = LENGTH_MASK
+
         fun packSymbol(symbol: Int, length: Int): Int = (symbol shl LENGTH_BITS) or length
 
         fun unpackSymbol(code: Int): Int = code ushr LENGTH_BITS
 
         fun unpackLength(code: Int): Int = code and LENGTH_MASK
 
-        fun fromFrequencies(frequencies: IntArray): HuffmanTree {
+        /**
+         * Redistributes [lengths] so that none exceeds [maxCodeLength].
+         *
+         * An unconstrained Huffman tree can be far deeper than DEFLATE permits: skewed frequencies
+         * push the rarest symbols past 15 bits, which neither the code-length alphabet of RFC1951
+         * 3.2.7 nor the packed table representation used here can express. Over-long codes are
+         * clamped to the limit, which leaves the tree over-subscribed, and the surplus is worked off
+         * by lengthening codes until the Kraft sum is back at exactly one. Lengths are then handed
+         * back out in order of decreasing frequency, so the most common symbols keep the shortest
+         * codes. The result is a valid, marginally sub-optimal code.
+         */
+        private fun limitCodeLengths(lengths: IntArray, frequencies: IntArray, maxCodeLength: Int) {
+            var longest = 0
+            for (length in lengths) {
+                if (length > longest) longest = length
+            }
+            if (longest <= maxCodeLength) return
+
+            // Kraft sums are tracked scaled by 2^maxCodeLength so they stay exact in integers.
+            val scale = 1L shl maxCodeLength
+            val counts = IntArray(maxCodeLength + 1)
+            var kraft = 0L
+            for (length in lengths) {
+                if (length == 0) continue
+                val clamped = if (length > maxCodeLength) maxCodeLength else length
+                counts[clamped]++
+                kraft += 1L shl (maxCodeLength - clamped)
+            }
+
+            // Clamping over-subscribes the tree, so lengthen the longest codes that still have room
+            // until it fits. Each move frees exactly half of that code's share.
+            while (kraft > scale) {
+                var bits = maxCodeLength - 1
+                while (bits > 0 && counts[bits] == 0) bits--
+                if (bits == 0) break // Unreachable: an over-subscribed tree always has a short code.
+                counts[bits]--
+                counts[bits + 1]++
+                kraft -= 1L shl (maxCodeLength - bits - 1)
+            }
+            // Lengthening can overshoot and leave capacity unused, which would make the code
+            // incomplete. Give it back to the deepest codes, smallest step first.
+            while (kraft < scale) {
+                var bits = maxCodeLength
+                while (bits > 1 && counts[bits] == 0) bits--
+                if (bits <= 1 || kraft + (1L shl (maxCodeLength - bits)) > scale) break
+                counts[bits]--
+                counts[bits - 1]++
+                kraft += 1L shl (maxCodeLength - bits)
+            }
+
+            val symbols = ArrayList<Int>()
+            for (symbol in lengths.indices) {
+                if (lengths[symbol] > 0) symbols.add(symbol)
+            }
+            symbols.sortWith(compareByDescending<Int> { frequencies[it] }.thenBy { it })
+            var index = 0
+            for (bits in 1..maxCodeLength) {
+                var remaining = counts[bits]
+                while (remaining > 0) {
+                    lengths[symbols[index++]] = bits
+                    remaining--
+                }
+            }
+        }
+
+        fun fromFrequencies(frequencies: IntArray, maxCodeLength: Int = MAX_CODE_LENGTH): HuffmanTree {
             var symbols = 0
             var onlySymbol = -1
             for (index in frequencies.indices) {
@@ -174,6 +242,7 @@ internal class HuffmanTree(
                 }
                 lengths[symbol] = length
             }
+            limitCodeLengths(lengths, frequencies, maxCodeLength)
 
             return HuffmanTree(lengths)
         }

--- a/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTreeLengthLimitTest.kt
+++ b/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTreeLengthLimitTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.huffman
+
+import dev.karmakrafts.kompress.deflate.DeflateConstants
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the RFC1951 code length ceiling.
+ *
+ * An unconstrained Huffman tree grows one level deeper per Fibonacci step, so skewed frequencies
+ * used to produce codes longer than the 15 bits RFC1951 3.2.7 allows, which corrupted the packed
+ * table representation and, deep enough, overflowed the decode table index outright.
+ */
+class HuffmanTreeLengthLimitTest {
+    private companion object {
+        /** Frequencies that force the deepest possible tree: one extra level per symbol. */
+        fun fibonacciFrequencies(count: Int): IntArray = IntArray(count).apply {
+            this[0] = 1
+            if (count > 1) this[1] = 1
+            for (index in 2 until count) this[index] = this[index - 1] + this[index - 2]
+        }
+
+        /**
+         * Asserts the lengths describe a usable prefix code: within [maxCodeLength], and with a
+         * Kraft sum of exactly one so the canonical assignment neither overruns nor leaves holes.
+         */
+        fun assertValidPrefixCode(lengths: IntArray, maxCodeLength: Int) {
+            var kraftNumerator = 0L
+            val scale = 1L shl maxCodeLength
+            for (length in lengths) {
+                if (length == 0) continue
+                assertTrue(length <= maxCodeLength, "code length $length exceeds $maxCodeLength")
+                kraftNumerator += scale shr length
+            }
+            assertEquals(scale, kraftNumerator, "code is not a complete prefix code")
+        }
+    }
+
+    @Test
+    fun `deeply skewed frequencies stay within the code length limit`() {
+        for (count in 2..64) {
+            val frequencies = fibonacciFrequencies(count)
+            val lengths = HuffmanTree.fromFrequencies(frequencies).codeLengths()
+            assertValidPrefixCode(lengths, HuffmanTree.MAX_CODE_LENGTH)
+        }
+    }
+
+    @Test
+    fun `code length alphabet trees stay within the three bit ceiling`() {
+        val frequencies = fibonacciFrequencies(DeflateConstants.CODE_LENGTH_ALPHABET_SIZE)
+        val lengths = HuffmanTree
+            .fromFrequencies(frequencies, DeflateConstants.MAX_CL_CODE_LENGTH)
+            .codeLengths()
+        assertValidPrefixCode(lengths, DeflateConstants.MAX_CL_CODE_LENGTH)
+    }
+
+    @Test
+    fun `limiting keeps the shortest codes on the most frequent symbols`() {
+        val frequencies = fibonacciFrequencies(40)
+        val lengths = HuffmanTree.fromFrequencies(frequencies).codeLengths()
+        // Symbol 39 is by far the most frequent, symbol 0 the rarest.
+        assertTrue(lengths[39] <= lengths[0], "frequent symbol got a longer code than a rare one")
+        assertValidPrefixCode(lengths, HuffmanTree.MAX_CODE_LENGTH)
+    }
+
+    @Test
+    fun `unskewed frequencies are left untouched`() {
+        val frequencies = IntArray(16) { 1 }
+        val lengths = HuffmanTree.fromFrequencies(frequencies).codeLengths()
+        // A balanced alphabet of 16 needs exactly four bits per symbol and no repair at all.
+        assertContentEquals(IntArray(16) { 4 }, lengths)
+    }
+
+    @Test
+    fun `symbols encode and decode through a limited tree`() {
+        val frequencies = fibonacciFrequencies(40)
+        val tree = HuffmanTree.fromFrequencies(frequencies)
+        for (symbol in frequencies.indices) {
+            val code = tree.encodingOf(symbol)
+            assertTrue(code.length in 1..HuffmanTree.MAX_CODE_LENGTH, "bad code length for $symbol")
+        }
+    }
+}

--- a/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTreeLengthLimitTest.kt
+++ b/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTreeLengthLimitTest.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,14 @@
 
 package dev.karmakrafts.kompress.huffman
 
+import dev.karmakrafts.karbide.BitOrder
+import dev.karmakrafts.karbide.bitSink
+import dev.karmakrafts.karbide.bitSource
 import dev.karmakrafts.kompress.deflate.DeflateConstants
+import dev.karmakrafts.kompress.deflate.Deflater
+import dev.karmakrafts.kompress.deflate.Inflater
+import kotlinx.io.Buffer
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -31,11 +38,46 @@ import kotlin.test.assertTrue
  */
 class HuffmanTreeLengthLimitTest {
     private companion object {
-        /** Frequencies that force the deepest possible tree: one extra level per symbol. */
-        fun fibonacciFrequencies(count: Int): IntArray = IntArray(count).apply {
-            this[0] = 1
-            if (count > 1) this[1] = 1
-            for (index in 2 until count) this[index] = this[index - 1] + this[index - 2]
+        /**
+         * The largest alphabet [fibonacciFrequencies] can describe.
+         *
+         * Frequencies grow as Fibonacci numbers and the tree builder sums them into a single [Int],
+         * so the total has to stay below [Int.MAX_VALUE]. Fib(1..44) already sums to 1836311902,
+         * and one step further overflows.
+         */
+        const val MAX_FIBONACCI_SYMBOLS: Int = 44
+
+        /**
+         * Frequencies that force the deepest possible tree: every extra symbol adds a level.
+         *
+         * [count] must not exceed [MAX_FIBONACCI_SYMBOLS], since silently wrapping into negative
+         * frequencies would drop symbols and quietly test a much shallower alphabet instead.
+         */
+        fun fibonacciFrequencies(count: Int): IntArray {
+            require(count in 2..MAX_FIBONACCI_SYMBOLS) { "Unsupported symbol count $count" }
+            return IntArray(count).apply {
+                this[0] = 1
+                this[1] = 1
+                for (index in 2 until count) this[index] = this[index - 1] + this[index - 2]
+                for (frequency in this) check(frequency > 0) { "Frequency overflowed" }
+            }
+        }
+
+        /** Bytes drawn from a Fibonacci weighted distribution, which deflates into a very deep tree. */
+        fun skewedPayload(size: Int): ByteArray {
+            val weights = fibonacciFrequencies(40)
+            var total = 0
+            for (weight in weights) total += weight
+            val random = Random(0x51DE)
+            return ByteArray(size) {
+                var remaining = random.nextInt(total)
+                var symbol = 0
+                while (symbol < weights.size - 1 && remaining >= weights[symbol]) {
+                    remaining -= weights[symbol]
+                    symbol++
+                }
+                symbol.toByte()
+            }
         }
 
         /**
@@ -56,7 +98,7 @@ class HuffmanTreeLengthLimitTest {
 
     @Test
     fun `deeply skewed frequencies stay within the code length limit`() {
-        for (count in 2..64) {
+        for (count in 2..MAX_FIBONACCI_SYMBOLS) {
             val frequencies = fibonacciFrequencies(count)
             val lengths = HuffmanTree.fromFrequencies(frequencies).codeLengths()
             assertValidPrefixCode(lengths, HuffmanTree.MAX_CODE_LENGTH)
@@ -90,12 +132,24 @@ class HuffmanTreeLengthLimitTest {
     }
 
     @Test
-    fun `symbols encode and decode through a limited tree`() {
+    fun `symbols round trip through a limited tree`() {
         val frequencies = fibonacciFrequencies(40)
         val tree = HuffmanTree.fromFrequencies(frequencies)
-        for (symbol in frequencies.indices) {
-            val code = tree.encodingOf(symbol)
-            assertTrue(code.length in 1..HuffmanTree.MAX_CODE_LENGTH, "bad code length for $symbol")
+        val buffer = Buffer()
+        buffer.bitSink(bitOrder = BitOrder.LSB_FIRST).use { sink ->
+            for (symbol in frequencies.indices) tree.encodeSymbol(sink, symbol)
         }
+        buffer.bitSource(bitOrder = BitOrder.LSB_FIRST).use { source ->
+            for (symbol in frequencies.indices) assertEquals(symbol, tree.decodeSymbol(source))
+        }
+    }
+
+    @Test
+    fun `heavily skewed data survives a deflate inflate round trip`() {
+        // Regression test for the reported symptom: a single block over enough skewed data used to
+        // need codes longer than 15 bits, producing a stream that could not be read back at all.
+        val data = skewedPayload(256 * 1024)
+        val compressed = Deflater.compress(data)
+        assertContentEquals(data, Inflater.decompress(compressed))
     }
 }


### PR DESCRIPTION
I'll give a bit of background on how I came across this. I was using Kompress for the iOS path of my app and I wanted use the same code for the jvm/android side as well. Before that, I wanted to verify that the performance wouldn't be drastically deteriorated. I had claude setup the benchmark for me, and while doing it, it reported this bug.

I don't know your opinion on AI code submissions. Feel free to close this without reading it if you're against them. I believe the issue is genuine and worth addressing.