### PR TITLE
Perf/inflate bit reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- `Deflater` emitting streams that could not be read back when Huffman code lengths exceeded the 15 bits RFC1951 allows, which affected sufficiently large or skewed inputs
+
 ## [2.3.1]
 
 ### Fixed

--- a/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/AbstractInflaterBenchmark.kt
+++ b/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/AbstractInflaterBenchmark.kt
@@ -22,13 +22,14 @@ import kotlinx.io.Buffer
 import kotlinx.io.readByteArray
 import kotlin.jvm.JvmName
 
-abstract class AbstractInflaterBenchmark(level: Int) {
+abstract class AbstractInflaterBenchmark(protected val data: ByteArray) {
     companion object {
         private const val DATA_SIZE: Int = 1024 * 1024 // 1MiB
     }
 
+    constructor(level: Int) : this(Deflater.compress(ByteArray(DATA_SIZE) { 1 }, level = level))
+
     protected val inflater: Inflater = Inflater()
-    protected val data: ByteArray = Deflater.compress(ByteArray(DATA_SIZE) { 1 }, level = level)
     protected val buffer: Buffer = Buffer()
     protected val chunkBuffer: ByteArray = ByteArray(4096)
 

--- a/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/InflaterStoredBenchmark.kt
+++ b/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/InflaterStoredBenchmark.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+
+/**
+ * Decompresses a raw DEFLATE stream made up of stored (BTYPE = 00) blocks.
+ */
+@State(Scope.Benchmark)
+open class InflaterStoredBenchmark : AbstractInflaterBenchmark(storedBenchmarkData())

--- a/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/InflaterTextBenchmark.kt
+++ b/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/InflaterTextBenchmark.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+
+/**
+ * Decompresses a deflated text like payload, which keeps the Huffman decoder busy
+ * instead of collapsing into a few long matches.
+ */
+@State(Scope.Benchmark)
+open class InflaterTextBenchmark : AbstractInflaterBenchmark(deflatedTextBenchmarkData())

--- a/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/StoredBlocks.kt
+++ b/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/StoredBlocks.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.io.writeShortLe
+
+internal const val STORED_DATA_SIZE: Int = 1024 * 1024 // 1MiB
+
+private const val MAX_STORED_BLOCK_SIZE: Int = 0xFFFF
+
+/**
+ * Encodes the given data as a chain of raw DEFLATE stored blocks.
+ *
+ * [Deflater] only ever emits static and dynamic blocks, so a stored stream has to be
+ * assembled by hand to exercise the BTYPE = 00 path of an inflater.
+ *
+ * See [RFC1951](https://datatracker.ietf.org/doc/html/rfc1951) section 3.2.4.
+ */
+internal fun storedBlocks(data: ByteArray): ByteArray {
+    val buffer = Buffer()
+    var offset = 0
+    do {
+        val length = minOf(MAX_STORED_BLOCK_SIZE, data.size - offset)
+        val isFinalBlock = offset + length >= data.size
+        // RFC1951 3.2.4: BFINAL followed by BTYPE = 00, padded up to the next byte boundary.
+        buffer.writeByte(if (isFinalBlock) 1 else 0)
+        // RFC1951 3.2.4: LEN and NLEN are little endian, NLEN being the one's complement of LEN.
+        buffer.writeShortLe(length.toShort())
+        buffer.writeShortLe((length xor MAX_STORED_BLOCK_SIZE).toShort())
+        buffer.write(data, offset, offset + length)
+        offset += length
+    }
+    while (offset < data.size)
+    return buffer.readByteArray()
+}
+
+/**
+ * The stored block equivalent of the payload every other inflate benchmark decompresses.
+ */
+internal fun storedBenchmarkData(): ByteArray = storedBlocks(ByteArray(STORED_DATA_SIZE) { 1 })

--- a/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/TextPayload.kt
+++ b/kompress-benchmarks/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/TextPayload.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlin.random.Random
+
+private val VOCABULARY: List<String> = listOf(
+    "deflate", "inflate", "kompress", "huffman", "window", "symbol", "literal", "distance",
+    "block", "stream", "buffer", "length", "offset", "table", "encode", "decode", "match",
+    "checksum", "dictionary", "compression"
+)
+
+/**
+ * Builds a deterministic, text like payload of [size] bytes.
+ *
+ * The other inflate benchmarks decompress a single repeated byte, which collapses into a handful of
+ * maximum length matches and barely touches the Huffman decoder. Prose sized words interleaved with
+ * punctuation keep the literal and short match paths busy instead, which is what real input looks like.
+ */
+internal fun textBenchmarkData(size: Int = STORED_DATA_SIZE): ByteArray {
+    val random = Random(0x5EED)
+    val buffer = Buffer()
+    var written = 0
+    while (written < size) {
+        val word = VOCABULARY[random.nextInt(VOCABULARY.size)]
+        val separator = if (random.nextInt(12) == 0) ".\n" else " "
+        val chunk = (word + separator).encodeToByteArray()
+        val length = minOf(chunk.size, size - written)
+        buffer.write(chunk, 0, length)
+        written += length
+    }
+    return buffer.readByteArray()
+}
+
+/**
+ * The text payload every text inflate benchmark decompresses, deflated at the default level.
+ *
+ * Deflated in chunks rather than in one call, so the stream carries a run of dynamic blocks the way
+ * real deflate output of this size does, rather than one outsized block.
+ */
+internal fun deflatedTextBenchmarkData(chunkSize: Int = 64 * 1024): ByteArray {
+    val data = textBenchmarkData()
+    val output = Buffer()
+    val chunk = ByteArray(4096)
+    Deflater(Deflater.DEFAULT_LEVEL).use { deflater ->
+        var offset = 0
+        while (offset < data.size) {
+            val size = minOf(chunkSize, data.size - offset)
+            deflater.setInput(data, offset, size)
+            offset += size
+            if (offset == data.size) deflater.finish()
+            while (true) {
+                val compressed = deflater.compress(chunk)
+                if (compressed == 0) break
+                output.write(chunk, 0, compressed)
+            }
+        }
+    }
+    return output.readByteArray()
+}

--- a/kompress-benchmarks/src/jvmMain/kotlin/dev/karmakrafts/kompress/deflate/AbstractJvmInflaterBenchmark.kt
+++ b/kompress-benchmarks/src/jvmMain/kotlin/dev/karmakrafts/kompress/deflate/AbstractJvmInflaterBenchmark.kt
@@ -22,13 +22,14 @@ import kotlinx.io.Buffer
 import kotlinx.io.readByteArray
 import java.util.zip.Inflater
 
-abstract class AbstractJvmInflaterBenchmark(level: Int) {
+abstract class AbstractJvmInflaterBenchmark(protected val data: ByteArray) {
     companion object {
         private const val DATA_SIZE: Int = 1024 * 1024 // 1MiB
     }
 
+    constructor(level: Int) : this(Deflater.compress(ByteArray(DATA_SIZE) { 1 }, level = level))
+
     protected val inflater: Inflater = Inflater(true)
-    protected val data: ByteArray = Deflater.compress(ByteArray(DATA_SIZE) { 1 }, level = level)
     protected val buffer: Buffer = Buffer()
     protected val chunkBuffer: ByteArray = ByteArray(4096)
 

--- a/kompress-benchmarks/src/jvmMain/kotlin/dev/karmakrafts/kompress/deflate/JvmInflaterStoredBenchmark.kt
+++ b/kompress-benchmarks/src/jvmMain/kotlin/dev/karmakrafts/kompress/deflate/JvmInflaterStoredBenchmark.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+
+/**
+ * Decompresses a raw DEFLATE stream made up of stored (BTYPE = 00) blocks.
+ */
+@State(Scope.Benchmark)
+open class JvmInflaterStoredBenchmark : AbstractJvmInflaterBenchmark(storedBenchmarkData())

--- a/kompress-benchmarks/src/jvmMain/kotlin/dev/karmakrafts/kompress/deflate/JvmInflaterTextBenchmark.kt
+++ b/kompress-benchmarks/src/jvmMain/kotlin/dev/karmakrafts/kompress/deflate/JvmInflaterTextBenchmark.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+
+/**
+ * Decompresses a deflated text like payload, which keeps the Huffman decoder busy
+ * instead of collapsing into a few long matches.
+ */
+@State(Scope.Benchmark)
+open class JvmInflaterTextBenchmark : AbstractJvmInflaterBenchmark(deflatedTextBenchmarkData())

--- a/kompress-benchmarks/src/nativeMain/kotlin/dev/karmakrafts/kompress/deflate/AbstractNativeInflaterBenchmark.kt
+++ b/kompress-benchmarks/src/nativeMain/kotlin/dev/karmakrafts/kompress/deflate/AbstractNativeInflaterBenchmark.kt
@@ -39,14 +39,15 @@ import platform.zlib.inflateReset
 import platform.zlib.z_stream
 
 @OptIn(ExperimentalForeignApi::class)
-abstract class AbstractNativeInflaterBenchmark(level: Int) {
+abstract class AbstractNativeInflaterBenchmark(protected val data: ByteArray) {
     private companion object {
         private const val DATA_SIZE: Int = 1024 * 1024 // 1MiB
         private const val RAW_WINDOW_BITS: Int = -15
     }
 
+    constructor(level: Int) : this(Deflater.compress(ByteArray(DATA_SIZE) { 1 }, level = level))
+
     protected val stream: z_stream = nativeHeap.alloc()
-    protected val data: ByteArray = Deflater.compress(ByteArray(DATA_SIZE) { 1 }, level = level)
     protected val buffer: Buffer = Buffer()
     protected val chunkBuffer: ByteArray = ByteArray(4096)
 

--- a/kompress-benchmarks/src/nativeMain/kotlin/dev/karmakrafts/kompress/deflate/NativeInflaterStoredBenchmark.kt
+++ b/kompress-benchmarks/src/nativeMain/kotlin/dev/karmakrafts/kompress/deflate/NativeInflaterStoredBenchmark.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+
+/**
+ * Decompresses a raw DEFLATE stream made up of stored (BTYPE = 00) blocks.
+ */
+@State(Scope.Benchmark)
+open class NativeInflaterStoredBenchmark : AbstractNativeInflaterBenchmark(storedBenchmarkData())

--- a/kompress-benchmarks/src/nativeMain/kotlin/dev/karmakrafts/kompress/deflate/NativeInflaterTextBenchmark.kt
+++ b/kompress-benchmarks/src/nativeMain/kotlin/dev/karmakrafts/kompress/deflate/NativeInflaterTextBenchmark.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+
+/**
+ * Decompresses a deflated text like payload, which keeps the Huffman decoder busy
+ * instead of collapsing into a few long matches.
+ */
+@State(Scope.Benchmark)
+open class NativeInflaterTextBenchmark : AbstractNativeInflaterBenchmark(deflatedTextBenchmarkData())

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/DeflateConstants.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/DeflateConstants.kt
@@ -40,6 +40,9 @@ internal object DeflateConstants {
     const val MAX_CODE_LENGTH: Int = 15
     const val CL_CODE_LENGTH_SIZE: Int = 3
 
+    /** Code-length codes are written as [CL_CODE_LENGTH_SIZE] bit values, so they cannot exceed this. */
+    const val MAX_CL_CODE_LENGTH: Int = (1 shl CL_CODE_LENGTH_SIZE) - 1
+
     const val BTYPE_SIZE: Int = 2
     const val BTYPE_STORED: ULong = 0b00UL
     const val BTYPE_STATIC: ULong = 0b01UL

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/DeflateConstants.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/DeflateConstants.kt
@@ -16,6 +16,8 @@
 
 package dev.karmakrafts.kompress.deflate
 
+import dev.karmakrafts.kompress.huffman.HuffmanTree
+
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -37,7 +39,7 @@ internal object DeflateConstants {
     const val DISTANCE_ALPHABET_SIZE: Int = 30
     const val CODE_LENGTH_ALPHABET_SIZE: Int = 19
 
-    const val MAX_CODE_LENGTH: Int = 15
+    const val MAX_CODE_LENGTH: Int = HuffmanTree.MAX_CODE_LENGTH
     const val CL_CODE_LENGTH_SIZE: Int = 3
 
     /** Code-length codes are written as [CL_CODE_LENGTH_SIZE] bit values, so they cannot exceed this. */

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/Deflater.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/Deflater.kt
@@ -284,7 +284,8 @@ internal class DeflaterImpl( // @formatter:off
         collectDynamicTreeSymbols(distanceLengths, distanceCodesCount)
 
         // RFC1951 3.2.7: derive the code-length tree from frequencies of lengths and repeat symbols.
-        val lengthTree = HuffmanTree.fromFrequencies(lengthFrequencies)
+        // Its own code lengths ship as three bit values, so they are capped tighter than the rest.
+        val lengthTree = HuffmanTree.fromFrequencies(lengthFrequencies, DeflateConstants.MAX_CL_CODE_LENGTH)
         val lengthTreeLengths = lengthTree.codeLengths()
         // RFC1951 3.2.7: HCLEN stores the number of code-length codes minus four.
         val codeLengthCodesCount = computeCodeLengthCodesCount(lengthTreeLengths)

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/Inflater.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/deflate/Inflater.kt
@@ -16,16 +16,12 @@
 
 package dev.karmakrafts.kompress.deflate
 
-import dev.karmakrafts.karbide.BitOrder
-import dev.karmakrafts.karbide.BitSource
-import dev.karmakrafts.karbide.bitSource
-import dev.karmakrafts.karbide.readBitsLsb
-import dev.karmakrafts.karbide.source
 import dev.karmakrafts.kompress.Decompressor
 import dev.karmakrafts.kompress.InternalCompressionApi
 import dev.karmakrafts.kompress.decompressingSink
 import dev.karmakrafts.kompress.decompressingSource
 import dev.karmakrafts.kompress.exception.DataFormatException
+import dev.karmakrafts.kompress.exception.NoSuchCodeException
 import dev.karmakrafts.kompress.huffman.HuffmanTree
 import dev.karmakrafts.kompress.lz77.LZ77
 import kotlinx.io.Buffer
@@ -147,7 +143,8 @@ internal class InflaterImpl(
 
     override val remaining: Int get() = (inputSize - bytesReadInCurrentInput()).coerceIn(0, inputSize)
 
-    override val bytesRead: Long get() = bitSource.byte + if (bitSource.bit > 0) 1 else 0
+    // Bits already pulled into bitBuffer but not yet consumed do not count as read yet.
+    override val bytesRead: Long get() = ((bytesPulled shl 3) - bitCount + 7) ushr 3
     override var bytesWritten: Long = 0L
         private set
     override val needsInput: Boolean get() = !finished && isInputNeeded
@@ -157,8 +154,14 @@ internal class InflaterImpl(
     private val windowSize: Int = window.size
     private val windowMask: Int = if (windowSize > 0 && windowSize and (windowSize - 1) == 0) windowSize - 1 else -1
     private val codeLengthLengths: IntArray = IntArray(DeflateConstants.CODE_LENGTH_ALPHABET_SIZE)
-    private val inputSource = input.source()
-    private val bitSource: BitSource = inputSource.buffered().bitSource(bitOrder = BitOrder.LSB_FIRST)
+    // DEFLATE is read as a little endian bit stream, so the next bit is always the low bit of
+    // bitBuffer. Holding it in fields and refilling a word at a time keeps symbol decoding down to
+    // plain arithmetic, instead of a call into a layered reader for every few bits.
+    private var bitBuffer: Long = 0L
+    private var bitCount: Int = 0
+    private var inputPosition: Int = 0
+    private var inputLimit: Int = 0
+    private var bytesPulled: Long = 0L
 
     private var isClosed: Boolean = false
     private var inputStart: Long = 0L
@@ -197,28 +200,69 @@ internal class InflaterImpl(
         inputOffset = offset
         inputSize = size
         inputStart = bytesRead
-        inputSource.array = data
-        inputSource.offset = offset
-        inputSource.size = size
-        inputSource.reset()
+        inputPosition = offset
+        inputLimit = offset + size
+        // Any bits still buffered belong to the previous chunk and stay put: a codeword is allowed
+        // to straddle the boundary between two calls.
         if (size > 0) {
             isInputNeeded = false
         }
     }
 
+    /** Tops the bit buffer up to at least 57 bits, or to whatever the current input can supply. */
+    private fun fillBits() {
+        var buffer = bitBuffer
+        var count = bitCount
+        var position = inputPosition
+        val limit = inputLimit
+        val input = input
+        while (count <= 56 && position < limit) {
+            buffer = buffer or ((input[position++].toLong() and 0xFF) shl count)
+            count += 8
+        }
+        bytesPulled += (position - inputPosition).toLong()
+        bitBuffer = buffer
+        bitCount = count
+        inputPosition = position
+    }
+
     private fun needBits(count: Int): Boolean {
-        if (bitSource.requestBits(count)) return true
+        if (bitCount >= count) return true
+        fillBits()
+        if (bitCount >= count) return true
         if (finishing) throw DataFormatException("Unexpected end of DEFLATE stream")
         isInputNeeded = true
         return false
     }
 
+    /** Reads [count] bits, which the caller must already have ensured are buffered. */
+    private fun readBits(count: Int): Int {
+        val value = (bitBuffer and ((1L shl count) - 1L)).toInt()
+        bitBuffer = bitBuffer ushr count
+        bitCount -= count
+        return value
+    }
+
+    private fun skipBits(count: Int) {
+        bitBuffer = bitBuffer ushr count
+        bitCount -= count
+    }
+
     private fun peekSymbol(tree: HuffmanTree): Int {
-        val code = tree.peekSymbolCode(bitSource)
+        if (bitCount < tree.maxBits) {
+            fillBits()
+            if (bitCount < tree.maxBits) {
+                // Near the end of the stream a short codeword may still be complete.
+                val partial = tree.symbolCodeWithin(bitBuffer, bitCount)
+                if (partial != HuffmanTree.NO_SYMBOL) return partial
+                if (finishing) throw DataFormatException("Unexpected end of DEFLATE stream")
+                isInputNeeded = true
+                return HuffmanTree.NO_SYMBOL
+            }
+        }
+        val code = tree.symbolCodeAt(bitBuffer)
         if (code != HuffmanTree.NO_SYMBOL) return code
-        if (finishing) throw DataFormatException("Unexpected end of DEFLATE stream")
-        isInputNeeded = true
-        return HuffmanTree.NO_SYMBOL
+        throw NoSuchCodeException("No symbol in huffman tree")
     }
 
     private fun writeLiteral(output: ByteArray, position: Int, value: Int): Int {
@@ -295,6 +339,18 @@ internal class InflaterImpl(
         val windowSize = windowSize
         var readPosition = initialReadPosition
         var writePosition = windowPosition
+        // Overwhelmingly the common case: the match clears both ends of the ring, so it moves in
+        // exactly two copies and skips all of the chunking the wrapping loop below has to do.
+        if (readPosition + copyLimit <= windowSize && writePosition + copyLimit <= windowSize) {
+            window.copyInto(output, position, readPosition, readPosition + copyLimit)
+            output.copyInto(window, writePosition, position, position + copyLimit)
+            var nextWritePosition = writePosition + copyLimit
+            if (nextWritePosition == windowSize) {
+                nextWritePosition = 0
+            }
+            finishMatchWrite(nextWritePosition, copyLimit, length)
+            return position + copyLimit
+        }
         var outputPosition = position
         var copied = 0
         while (copied < copyLimit) {
@@ -406,7 +462,7 @@ internal class InflaterImpl(
      */
     private fun decodeBlockHeader(): Boolean {
         if (!needBits(1 + DeflateConstants.BTYPE_SIZE)) return false
-        val header = bitSource.readBitsLsb(1 + DeflateConstants.BTYPE_SIZE).toInt()
+        val header = readBits(1 + DeflateConstants.BTYPE_SIZE)
         // RFC1951 3.2.3: BFINAL marks the last block, followed by two BTYPE bits.
         isFinalBlock = (header and 1) != 0
         when (header ushr 1) {
@@ -431,14 +487,16 @@ internal class InflaterImpl(
      * See [RFC1951](https://datatracker.ietf.org/doc/html/rfc1951) section 3.2.4.
      */
     private fun decodeStoredHeader(): Boolean {
-        val padding = (Byte.SIZE_BITS - bitSource.bit) and 7
+        // Consumed bits are the complement of what is still buffered, so the distance to the next
+        // byte boundary is simply the buffered remainder.
+        val padding = bitCount and 7
         if (!needBits(padding)) return false
         if (padding > 0) {
-            bitSource.skipBits(padding)
+            skipBits(padding)
         }
         if (!needBits(Short.SIZE_BITS * 2)) return false
-        val length = bitSource.readBitsLsb(Short.SIZE_BITS).toInt()
-        val inverseLength = bitSource.readBitsLsb(Short.SIZE_BITS).toInt()
+        val length = readBits(Short.SIZE_BITS)
+        val inverseLength = readBits(Short.SIZE_BITS)
         // RFC1951 3.2.4: NLEN is the one's-complement of LEN.
         if ((length xor 0xFFFF) != inverseLength) {
             throw DataFormatException("Invalid stored block length check")
@@ -451,43 +509,84 @@ internal class InflaterImpl(
     /**
      * Copies the uncompressed bytes from a stored block.
      *
+     * Stored blocks are byte aligned and carry no coding, so the payload is pulled out of the bit
+     * source a word at a time and mirrored into the sliding window in bulk once the output region
+     * is complete. Nothing inside a stored block can back-reference the window, so deferring that
+     * copy until the end of the call is safe.
+     *
      * See [RFC1951](https://datatracker.ietf.org/doc/html/rfc1951) section 3.2.4.
      */
     private fun inflateStoredBlock(output: ByteArray, position: Int, limit: Int): Int {
+        // The header left the stream byte aligned, so hand whole buffered bytes back to the input
+        // cursor. The payload can then be copied straight out of the caller's array.
+        val bufferedBytes = bitCount ushr 3
+        if (bufferedBytes > 0) {
+            inputPosition -= bufferedBytes
+            bytesPulled -= bufferedBytes.toLong()
+            bitBuffer = 0L
+            bitCount = 0
+        }
         var outputPosition = position
         var remaining = storedRemaining
-        val window = window
-        val windowSize = windowSize
-        val windowMask = windowMask
-        var writePosition = windowPosition
         val startPosition = outputPosition
-        while (remaining > 0 && outputPosition < limit) {
-            if (!needBits(Byte.SIZE_BITS)) break
-            val byte = bitSource.readBitsLsb(Byte.SIZE_BITS).toByte()
-            output[outputPosition++] = byte
-            window[writePosition] = byte
-            if (windowMask != -1) {
-                writePosition = (writePosition + 1) and windowMask
-            }
-            else {
-                writePosition++
-                if (writePosition == windowSize) {
-                    writePosition = 0
-                }
-            }
-            remaining--
+        val available = inputLimit - inputPosition
+        var count = if (remaining < available) remaining else available
+        val space = limit - outputPosition
+        if (count > space) count = space
+        if (count > 0) {
+            input.copyInto(output, outputPosition, inputPosition, inputPosition + count)
+            inputPosition += count
+            bytesPulled += count.toLong()
+            outputPosition += count
+            remaining -= count
         }
         storedRemaining = remaining
-        windowPosition = writePosition
         val copied = outputPosition - startPosition
         if (copied > 0) {
-            val filled = windowFilled
-            windowFilled = if (windowSize - filled > copied) filled + copied else windowSize
+            writeToWindow(output, startPosition, copied)
         }
         if (remaining == 0) {
             finishBlock()
         }
+        else if (available == count && outputPosition < limit) {
+            // Ran the current input dry mid block rather than filling the output.
+            if (finishing) throw DataFormatException("Unexpected end of DEFLATE stream")
+            isInputNeeded = true
+        }
         return outputPosition
+    }
+
+    /**
+     * Mirrors [count] freshly written output bytes into the sliding history window.
+     */
+    private fun writeToWindow(output: ByteArray, position: Int, count: Int) {
+        val window = window
+        val windowSize = windowSize
+        var sourcePosition = position
+        var pending = count
+        var writePosition = windowPosition
+        if (pending >= windowSize) {
+            // Only the trailing window worth of bytes stays reachable, and it fills the window
+            // exactly once, so the write position ends up right back where this copy starts.
+            val skipped = pending - windowSize
+            sourcePosition += skipped
+            pending = windowSize
+            writePosition = if (windowMask != -1) (writePosition + skipped) and windowMask
+            else ((writePosition.toLong() + skipped) % windowSize).toInt()
+        }
+        while (pending > 0) {
+            val chunk = minOf(pending, windowSize - writePosition)
+            output.copyInto(window, writePosition, sourcePosition, sourcePosition + chunk)
+            sourcePosition += chunk
+            writePosition += chunk
+            if (writePosition == windowSize) {
+                writePosition = 0
+            }
+            pending -= chunk
+        }
+        windowPosition = writePosition
+        val filled = windowFilled
+        windowFilled = if (windowSize - filled > count) filled + count else windowSize
     }
 
     /**
@@ -500,7 +599,7 @@ internal class InflaterImpl(
             if (!needBits(DeflateConstants.CL_CODE_LENGTH_SIZE)) return false
             // RFC1951 3.2.7: code-length code lengths are serialized in CODE_LENGTH_ORDER.
             val index = DeflateConstants.CODE_LENGTH_ORDER[dynamicCodeLengthIndex++]
-            codeLengthLengths[index] = bitSource.readBitsLsb(DeflateConstants.CL_CODE_LENGTH_SIZE).toInt()
+            codeLengthLengths[index] = readBits(DeflateConstants.CL_CODE_LENGTH_SIZE)
         }
         // RFC1951 3.2.7: this tree decodes the literal/length and distance code lengths.
         dynamicLengthTree = HuffmanTree(codeLengthLengths, buildEncodeTable = false)
@@ -528,7 +627,7 @@ internal class InflaterImpl(
                 else -> throw DataFormatException("Invalid code length symbol: $symbol")
             }
             if (extraBits > 0 && !needBits(codeLength + extraBits)) return false
-            bitSource.skipBits(codeLength)
+            skipBits(codeLength)
             when (symbol) {
                 in 0..DeflateConstants.MAX_CODE_LENGTH -> {
                     dynamicLengths[dynamicLengthIndex++] = symbol
@@ -542,7 +641,7 @@ internal class InflaterImpl(
                     // RFC1951 3.2.7: code 16 repeats the previous non-zero length 3-6 times using
                     // 2 extra bits.
                     val repeatCount =
-                        DeflateConstants.SYM_REPEAT_PREVIOUS_MIN + bitSource.readBitsLsb(extraBits).toInt()
+                        DeflateConstants.SYM_REPEAT_PREVIOUS_MIN + readBits(extraBits)
                     if (dynamicLengthIndex + repeatCount > dynamicLengthsCount) {
                         throw DataFormatException("Code length repeat exceeds dynamic tree size")
                     }
@@ -554,7 +653,7 @@ internal class InflaterImpl(
                 DeflateConstants.SYM_REPEAT_ZERO_LENGTH -> {
                     // RFC1951 3.2.7: code 17 repeats zero lengths 3-10 times using 3 extra bits.
                     val repeatCount =
-                        DeflateConstants.SYM_REPEAT_ZERO_LENGTH_MIN + bitSource.readBitsLsb(extraBits).toInt()
+                        DeflateConstants.SYM_REPEAT_ZERO_LENGTH_MIN + readBits(extraBits)
                     if (dynamicLengthIndex + repeatCount > dynamicLengthsCount) {
                         throw DataFormatException("Code length repeat exceeds dynamic tree size")
                     }
@@ -566,7 +665,7 @@ internal class InflaterImpl(
                 DeflateConstants.SYM_LONG_ZERO_LENGTH_RUN -> {
                     // RFC1951 3.2.7: code 18 repeats zero lengths 11-138 times using 7 extra bits.
                     val repeatCount =
-                        DeflateConstants.SYM_LONG_ZERO_LENGTH_RUN_MIN + bitSource.readBitsLsb(extraBits).toInt()
+                        DeflateConstants.SYM_LONG_ZERO_LENGTH_RUN_MIN + readBits(extraBits)
                     if (dynamicLengthIndex + repeatCount > dynamicLengthsCount) {
                         throw DataFormatException("Code length repeat exceeds dynamic tree size")
                     }
@@ -599,11 +698,11 @@ internal class InflaterImpl(
             // RFC1951 3.2.7: HLIT, HDIST and HCLEN store count values minus their RFC-defined
             // offsets.
             dynamicLiteralCodesCount =
-                DeflateConstants.HLIT_OFFSET + bitSource.readBitsLsb(DeflateConstants.HLIT_SIZE).toInt()
+                DeflateConstants.HLIT_OFFSET + readBits(DeflateConstants.HLIT_SIZE)
             dynamicDistanceCodesCount =
-                DeflateConstants.HDIST_OFFSET + bitSource.readBitsLsb(DeflateConstants.HDIST_SIZE).toInt()
+                DeflateConstants.HDIST_OFFSET + readBits(DeflateConstants.HDIST_SIZE)
             dynamicCodeLengthCodesCount =
-                DeflateConstants.HCLEN_OFFSET + bitSource.readBitsLsb(DeflateConstants.HCLEN_SIZE).toInt()
+                DeflateConstants.HCLEN_OFFSET + readBits(DeflateConstants.HCLEN_SIZE)
             dynamicLengthsCount = dynamicLiteralCodesCount + dynamicDistanceCodesCount
             if (dynamicLengthsCount > dynamicLengths.size) {
                 throw DataFormatException("Dynamic tree size exceeds maximum")
@@ -631,10 +730,18 @@ internal class InflaterImpl(
         // RFC1951 3.2.5: distance symbols may be followed by extra bits added to the base
         // distance.
         val extraBits = DeflateConstants.DIST_EXTRA_BITS[distanceSymbol]
-        if (extraBits > 0 && !needBits(codeLength + extraBits)) return position
-        bitSource.skipBits(codeLength)
-        val distance = DeflateConstants.DIST_BASE[distanceSymbol] + if (extraBits == 0) 0
-        else bitSource.readBitsLsb(extraBits).toInt()
+        val distance: Int
+        if (extraBits == 0) {
+            skipBits(codeLength)
+            distance = DeflateConstants.DIST_BASE[distanceSymbol]
+        }
+        else {
+            if (!needBits(codeLength + extraBits)) return position
+            // The code and its extra bits are adjacent in the stream, so one read covers both:
+            // LSB-first puts the code in the low bits and the extra bits directly above it.
+            val bits = readBits(codeLength + extraBits).toLong()
+            distance = DeflateConstants.DIST_BASE[distanceSymbol] + (bits ushr codeLength).toInt()
+        }
         return writeMatch(output, position, limit, pendingLength, distance)
     }
 
@@ -658,13 +765,13 @@ internal class InflaterImpl(
             val codeLength = HuffmanTree.unpackLength(code)
             when {
                 symbol < DeflateConstants.SYM_EOF -> {
-                    bitSource.skipBits(codeLength)
+                    skipBits(codeLength)
                     outputPosition = writeLiteral(output, outputPosition, symbol)
                 }
 
                 symbol == DeflateConstants.SYM_EOF -> {
                     // RFC1951 3.2.3: literal/length symbol 256 marks the end of the block.
-                    bitSource.skipBits(codeLength)
+                    skipBits(codeLength)
                     finishBlock()
                     return outputPosition
                 }
@@ -674,10 +781,16 @@ internal class InflaterImpl(
                     // RFC1951 3.2.5: length symbols may be followed by extra bits added to the
                     // base length.
                     val extraBits = DeflateConstants.LENGTH_EXTRA_BITS[index]
-                    if (extraBits > 0 && !needBits(codeLength + extraBits)) return outputPosition
-                    bitSource.skipBits(codeLength)
-                    pendingLength = DeflateConstants.LENGTH_BASE[index] + if (extraBits == 0) 0
-                    else bitSource.readBitsLsb(extraBits).toInt()
+                    if (extraBits == 0) {
+                        skipBits(codeLength)
+                        pendingLength = DeflateConstants.LENGTH_BASE[index]
+                    }
+                    else {
+                        if (!needBits(codeLength + extraBits)) return outputPosition
+                        // One read covers the code and its extra bits, which sit directly above it.
+                        val bits = readBits(codeLength + extraBits).toLong()
+                        pendingLength = DeflateConstants.LENGTH_BASE[index] + (bits ushr codeLength).toInt()
+                    }
                     outputPosition = decodeMatch(output, outputPosition, limit)
                     if (pendingLength > 0) return outputPosition
                 }
@@ -733,11 +846,11 @@ internal class InflaterImpl(
         input = ByteArray(0)
         inputOffset = 0
         inputSize = 0
-        inputSource.array = input
-        inputSource.offset = 0
-        inputSource.size = 0
-        inputSource.reset()
-        bitSource.reset()
+        bitBuffer = 0L
+        bitCount = 0
+        inputPosition = 0
+        inputLimit = 0
+        bytesPulled = 0L
         inputStart = 0L
         window.fill(0)
         windowPosition = 0
@@ -759,7 +872,6 @@ internal class InflaterImpl(
 
     override fun close() {
         if (isClosed) return
-        bitSource.close()
         isClosed = true
     }
 }

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
@@ -82,8 +82,16 @@ internal class HuffmanTree(
         private const val LENGTH_BITS: Int = 4
         private const val LENGTH_MASK: Int = (1 shl LENGTH_BITS) - 1
 
-        /** The longest code RFC1951 permits, which is also all the packed representation can hold. */
-        const val MAX_CODE_LENGTH: Int = LENGTH_MASK
+        /** The longest codeword RFC1951 3.2.7 permits. */
+        const val MAX_CODE_LENGTH: Int = 15
+
+        init {
+            // The packed representation stores the length in LENGTH_BITS bits. Widening the RFC
+            // limit without widening the packing would silently truncate lengths.
+            check(MAX_CODE_LENGTH <= LENGTH_MASK) {
+                "MAX_CODE_LENGTH $MAX_CODE_LENGTH does not fit in $LENGTH_BITS bits"
+            }
+        }
 
         fun packSymbol(symbol: Int, length: Int): Int = (symbol shl LENGTH_BITS) or length
 
@@ -125,7 +133,10 @@ internal class HuffmanTree(
             while (kraft > scale) {
                 var bits = maxCodeLength - 1
                 while (bits > 0 && counts[bits] == 0) bits--
-                if (bits == 0) break // Unreachable: an over-subscribed tree always has a short code.
+                // Only reachable if the alphabet cannot fit under maxCodeLength at all, which would
+                // mean more than 2^maxCodeLength used symbols. Failing here beats handing back an
+                // over-subscribed tree that corrupts the decode table later.
+                check(bits > 0) { "Cannot fit alphabet into $maxCodeLength bit codes" }
                 counts[bits]--
                 counts[bits + 1]++
                 kraft -= 1L shl (maxCodeLength - bits - 1)

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
@@ -18,6 +18,7 @@ package dev.karmakrafts.kompress.huffman
 
 import dev.karmakrafts.karbide.BitSink
 import dev.karmakrafts.karbide.BitSource
+import dev.karmakrafts.karbide.peekBitsLsb
 import dev.karmakrafts.kompress.exception.NoSuchCodeException
 import dev.karmakrafts.kompress.exception.NoSuchSymbolException
 
@@ -33,7 +34,9 @@ internal class HuffmanTree(
     buildEncodeTable: Boolean = true
 ) {
     private val encodeTable: LongArray? = if (buildEncodeTable) LongArray(size) else null
-    private var maxBits: Int = 0
+    /** Width of the decode table index, i.e. the length of the longest codeword. */
+    var maxBits: Int = 0
+        private set
     private val decodeTable: IntArray
 
     init {
@@ -48,7 +51,8 @@ internal class HuffmanTree(
             if (length == 0) continue
             bitLengthCounts[length]++
         }
-        decodeTable = IntArray(if (maxBits == 0) 0 else 1 shl maxBits) { NO_SYMBOL }
+        val decodeTableSize = if (maxBits == 0) 0 else 1 shl maxBits
+        decodeTable = IntArray(decodeTableSize) { NO_SYMBOL }
         // Compute canonical next code table.
         // See RFC1951 3.2.2, step 2.
         val nextCode = IntArray(maxBits + 1)
@@ -66,12 +70,15 @@ internal class HuffmanTree(
             val code = HuffmanCode(canonical, bitLength)
             encodeTable?.set(symbol, code.value.toLong())
             val packed = packSymbol(symbol, bitLength)
-            val suffixBits = maxBits - bitLength
-            val endIndex = (canonical + 1) shl suffixBits
-            var index = canonical shl suffixBits
-            while (index < endIndex) {
+            // DEFLATE sends codeword bits most significant first inside an LSB-first stream, so the
+            // table is keyed by the reversed codeword. A decoder can then index it with the raw next
+            // bits of the stream, with the bits following the codeword landing in the high index
+            // bits, which every entry for this codeword covers.
+            var index = reverseCode(canonical, bitLength)
+            val stride = 1 shl bitLength
+            while (index < decodeTableSize) {
                 decodeTable[index] = packed
-                index++
+                index += stride
             }
         }
     }
@@ -98,6 +105,17 @@ internal class HuffmanTree(
         fun unpackSymbol(code: Int): Int = code ushr LENGTH_BITS
 
         fun unpackLength(code: Int): Int = code and LENGTH_MASK
+
+        /** Reverses the low [length] bits of [value], mapping a canonical codeword to stream order. */
+        private fun reverseCode(value: Int, length: Int): Int {
+            var result = 0
+            var remaining = value
+            for (bit in 0 until length) {
+                result = (result shl 1) or (remaining and 1)
+                remaining = remaining shr 1
+            }
+            return result
+        }
 
         /**
          * Redistributes [lengths] so that none exceeds [maxCodeLength].
@@ -278,21 +296,45 @@ internal class HuffmanTree(
     }
 
     private fun exactSymbolCode(bits: Int, length: Int): Int {
-        val code = decodeTable[bits shl (maxBits - length)]
+        // Reversed keying means the raw low bits address the entry directly.
+        val code = decodeTable[bits]
         if (code != NO_SYMBOL && unpackLength(code) == length) return code
+        return NO_SYMBOL
+    }
+
+    /**
+     * Decodes the codeword sitting at the low end of [bits], which must hold at least [maxBits]
+     * valid stream bits. Returns [NO_SYMBOL] only for a tree that has no codes at all.
+     */
+    fun symbolCodeAt(bits: Long): Int {
+        val table = decodeTable
+        if (table.isEmpty()) return NO_SYMBOL
+        return table[bits.toInt() and (table.size - 1)]
+    }
+
+    /**
+     * Decodes the codeword at the low end of [bits] when only [available] bits are known valid,
+     * which is the case at the very end of a stream. Returns [NO_SYMBOL] if no codeword fits.
+     */
+    fun symbolCodeWithin(bits: Long, available: Int): Int {
+        val limit = if (available < maxBits) available else maxBits
+        for (length in 1..limit) {
+            val code = decodeTable[bits.toInt() and ((1 shl length) - 1)]
+            if (code != NO_SYMBOL && unpackLength(code) == length) return code
+        }
         return NO_SYMBOL
     }
 
     fun peekSymbolCode(source: BitSource): Int {
         if (maxBits == 0) throw NoSuchCodeException("No symbol in huffman tree")
         if (source.requestBits(maxBits)) {
-            val code = decodeTable[source.peekBits(maxBits).toInt()]
+            val code = decodeTable[source.peekBitsLsb(maxBits).toInt()]
             if (code != NO_SYMBOL) return code
             throw NoSuchCodeException("No symbol in huffman tree")
         }
         for (length in 1..maxBits) {
             if (!source.requestBits(length)) return NO_SYMBOL
-            val bits = source.peekBits(length).toInt()
+            val bits = source.peekBitsLsb(length).toInt()
             val code = exactSymbolCode(bits, length)
             if (code != NO_SYMBOL) return code
         }

--- a/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
+++ b/kompress-core/src/commonMain/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTree.kt
@@ -82,13 +82,81 @@ internal class HuffmanTree(
         private const val LENGTH_BITS: Int = 4
         private const val LENGTH_MASK: Int = (1 shl LENGTH_BITS) - 1
 
+        /** The longest code RFC1951 permits, which is also all the packed representation can hold. */
+        const val MAX_CODE_LENGTH: Int = LENGTH_MASK
+
         fun packSymbol(symbol: Int, length: Int): Int = (symbol shl LENGTH_BITS) or length
 
         fun unpackSymbol(code: Int): Int = code ushr LENGTH_BITS
 
         fun unpackLength(code: Int): Int = code and LENGTH_MASK
 
-        fun fromFrequencies(frequencies: IntArray): HuffmanTree {
+        /**
+         * Redistributes [lengths] so that none exceeds [maxCodeLength].
+         *
+         * An unconstrained Huffman tree can be far deeper than DEFLATE permits: skewed frequencies
+         * push the rarest symbols past 15 bits, which neither the code-length alphabet of RFC1951
+         * 3.2.7 nor the packed table representation used here can express. Over-long codes are
+         * clamped to the limit, which leaves the tree over-subscribed, and the surplus is worked off
+         * by lengthening codes until the Kraft sum is back at exactly one. Lengths are then handed
+         * back out in order of decreasing frequency, so the most common symbols keep the shortest
+         * codes. The result is a valid, marginally sub-optimal code.
+         */
+        private fun limitCodeLengths(lengths: IntArray, frequencies: IntArray, maxCodeLength: Int) {
+            var longest = 0
+            for (length in lengths) {
+                if (length > longest) longest = length
+            }
+            if (longest <= maxCodeLength) return
+
+            // Kraft sums are tracked scaled by 2^maxCodeLength so they stay exact in integers.
+            val scale = 1L shl maxCodeLength
+            val counts = IntArray(maxCodeLength + 1)
+            var kraft = 0L
+            for (length in lengths) {
+                if (length == 0) continue
+                val clamped = if (length > maxCodeLength) maxCodeLength else length
+                counts[clamped]++
+                kraft += 1L shl (maxCodeLength - clamped)
+            }
+
+            // Clamping over-subscribes the tree, so lengthen the longest codes that still have room
+            // until it fits. Each move frees exactly half of that code's share.
+            while (kraft > scale) {
+                var bits = maxCodeLength - 1
+                while (bits > 0 && counts[bits] == 0) bits--
+                if (bits == 0) break // Unreachable: an over-subscribed tree always has a short code.
+                counts[bits]--
+                counts[bits + 1]++
+                kraft -= 1L shl (maxCodeLength - bits - 1)
+            }
+            // Lengthening can overshoot and leave capacity unused, which would make the code
+            // incomplete. Give it back to the deepest codes, smallest step first.
+            while (kraft < scale) {
+                var bits = maxCodeLength
+                while (bits > 1 && counts[bits] == 0) bits--
+                if (bits <= 1 || kraft + (1L shl (maxCodeLength - bits)) > scale) break
+                counts[bits]--
+                counts[bits - 1]++
+                kraft += 1L shl (maxCodeLength - bits)
+            }
+
+            val symbols = ArrayList<Int>()
+            for (symbol in lengths.indices) {
+                if (lengths[symbol] > 0) symbols.add(symbol)
+            }
+            symbols.sortWith(compareByDescending<Int> { frequencies[it] }.thenBy { it })
+            var index = 0
+            for (bits in 1..maxCodeLength) {
+                var remaining = counts[bits]
+                while (remaining > 0) {
+                    lengths[symbols[index++]] = bits
+                    remaining--
+                }
+            }
+        }
+
+        fun fromFrequencies(frequencies: IntArray, maxCodeLength: Int = MAX_CODE_LENGTH): HuffmanTree {
             var symbols = 0
             var onlySymbol = -1
             for (index in frequencies.indices) {
@@ -174,6 +242,7 @@ internal class HuffmanTree(
                 }
                 lengths[symbol] = length
             }
+            limitCodeLengths(lengths, frequencies, maxCodeLength)
 
             return HuffmanTree(lengths)
         }

--- a/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/deflate/StoredBlockInflaterTest.kt
+++ b/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/deflate/StoredBlockInflaterTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.deflate
+
+import dev.karmakrafts.kompress.exception.DataFormatException
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Covers the stored (BTYPE = 00) block path of [Inflater].
+ *
+ * [Deflater] only ever emits static and dynamic blocks, so every stored stream used here
+ * has to be assembled by hand.
+ *
+ * See [RFC1951](https://datatracker.ietf.org/doc/html/rfc1951) section 3.2.4.
+ */
+class StoredBlockInflaterTest {
+    private companion object {
+        const val MAX_STORED_BLOCK_SIZE: Int = 0xFFFF
+
+        val SMALL_DATA: ByteArray = "The quick brown fox jumps over the lazy dog".encodeToByteArray()
+        val LARGE_DATA: ByteArray = ByteArray(150_000) { index -> ((index * 31 + index / 7) and 0xFF).toByte() }
+
+        /** The 64 byte payload the mixed stream below stores, then back-references. */
+        val DICTIONARY_DATA: ByteArray = ByteArray(64) { index -> ((index * 37 + 11) and 0xFF).toByte() }
+
+        /**
+         * A final fixed-Huffman block holding a single length 64, distance 64 match, produced by
+         * zlib with [DICTIONARY_DATA] as its preset dictionary. Appended to a stored block holding
+         * [DICTIONARY_DATA] it must inflate to that payload twice, which only works if the stored
+         * block populated the sliding window.
+         */
+        val BACK_REFERENCE_BLOCK: ByteArray = byteArrayOf(
+            0xE3.toByte(), 0xA6.toByte(), 0x50, 0x3F, 0x00
+        )
+
+        /** Encodes [data] as a chain of stored blocks of at most [blockSize] bytes each. */
+        fun storedBlocks( // @formatter:off
+            data: ByteArray,
+            blockSize: Int = MAX_STORED_BLOCK_SIZE,
+            finalBlock: Boolean = true
+        ): ByteArray { // @formatter:on
+            val buffer = Buffer()
+            var offset = 0
+            do {
+                val length = minOf(blockSize, data.size - offset)
+                val isLast = finalBlock && offset + length >= data.size
+                buffer.writeByte(if (isLast) 1 else 0)
+                buffer.writeByte((length and 0xFF).toByte())
+                buffer.writeByte(((length ushr 8) and 0xFF).toByte())
+                val inverseLength = length xor MAX_STORED_BLOCK_SIZE
+                buffer.writeByte((inverseLength and 0xFF).toByte())
+                buffer.writeByte(((inverseLength ushr 8) and 0xFF).toByte())
+                buffer.write(data, offset, offset + length)
+                offset += length
+            }
+            while (offset < data.size)
+            return buffer.readByteArray()
+        }
+
+        /** Feeds [data] to [inflater] in [inputChunk] sized pieces, draining [outputChunk] bytes at a time. */
+        fun inflateChunked(data: ByteArray, inputChunk: Int, outputChunk: Int): ByteArray {
+            val output = Buffer()
+            val chunk = ByteArray(outputChunk)
+            Inflater().use { inflater ->
+                var offset = 0
+                while (offset < data.size) {
+                    val size = minOf(inputChunk, data.size - offset)
+                    inflater.setInput(data, offset, size)
+                    offset += size
+                    if (offset == data.size) inflater.finish()
+                    while (true) {
+                        val read = inflater.decompress(chunk, 0, chunk.size, flush = true)
+                        if (read == 0) break
+                        output.write(chunk, 0, read)
+                    }
+                }
+                assertTrue(inflater.finished, "inflater did not reach the end of the stream")
+            }
+            return output.readByteArray()
+        }
+    }
+
+    @Test
+    fun `single stored block round trips`() {
+        assertContentEquals(SMALL_DATA, Inflater.decompress(storedBlocks(SMALL_DATA)))
+    }
+
+    @Test
+    fun `empty stored block round trips`() {
+        assertContentEquals(ByteArray(0), Inflater.decompress(storedBlocks(ByteArray(0))))
+    }
+
+    @Test
+    fun `stored payload spanning multiple blocks round trips`() {
+        val compressedData = storedBlocks(LARGE_DATA)
+        // 150000 bytes cannot fit a single block, so the encoder must have split it.
+        assertEquals(3, (LARGE_DATA.size + MAX_STORED_BLOCK_SIZE - 1) / MAX_STORED_BLOCK_SIZE)
+        assertContentEquals(LARGE_DATA, Inflater.decompress(compressedData, bufferSize = 4096))
+    }
+
+    @Test
+    fun `stored block round trips through small output buffers`() {
+        val compressedData = storedBlocks(LARGE_DATA, blockSize = 1000)
+        assertContentEquals(LARGE_DATA, Inflater.decompress(compressedData, bufferSize = 7))
+    }
+
+    @Test
+    fun `stored block round trips when input arrives in small pieces`() {
+        val compressedData = storedBlocks(LARGE_DATA, blockSize = 4096)
+        assertContentEquals(LARGE_DATA, inflateChunked(compressedData, inputChunk = 13, outputChunk = 11))
+    }
+
+    @Test
+    fun `stored block spanning the sliding window round trips`() {
+        // Larger than the 32KiB window, so the window must wrap while the block is copied.
+        val data = ByteArray(70_000) { index -> ((index * 91 + 7) and 0xFF).toByte() }
+        assertContentEquals(data, Inflater.decompress(storedBlocks(data, blockSize = 9973)))
+    }
+
+    @Test
+    fun `compressed block back-references data from a preceding stored block`() {
+        val compressedData = storedBlocks(DICTIONARY_DATA, finalBlock = false) + BACK_REFERENCE_BLOCK
+        assertContentEquals(DICTIONARY_DATA + DICTIONARY_DATA, Inflater.decompress(compressedData))
+    }
+
+    @Test
+    fun `stored block with a corrupt length check is rejected`() {
+        val compressedData = storedBlocks(SMALL_DATA)
+        compressedData[3] = (compressedData[3] + 1).toByte() // Break NLEN
+        assertFailsWith<DataFormatException> { Inflater.decompress(compressedData) }
+    }
+
+    @Test
+    fun `truncated stored block is rejected`() {
+        val compressedData = storedBlocks(SMALL_DATA)
+        assertFailsWith<DataFormatException> { Inflater.decompress(compressedData.copyOf(compressedData.size - 4)) }
+    }
+}

--- a/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTreeLengthLimitTest.kt
+++ b/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTreeLengthLimitTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Karma Krafts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.karmakrafts.kompress.huffman
+
+import dev.karmakrafts.kompress.deflate.DeflateConstants
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the RFC1951 code length ceiling.
+ *
+ * An unconstrained Huffman tree grows one level deeper per Fibonacci step, so skewed frequencies
+ * used to produce codes longer than the 15 bits RFC1951 3.2.7 allows, which corrupted the packed
+ * table representation and, deep enough, overflowed the decode table index outright.
+ */
+class HuffmanTreeLengthLimitTest {
+    private companion object {
+        /** Frequencies that force the deepest possible tree: one extra level per symbol. */
+        fun fibonacciFrequencies(count: Int): IntArray = IntArray(count).apply {
+            this[0] = 1
+            if (count > 1) this[1] = 1
+            for (index in 2 until count) this[index] = this[index - 1] + this[index - 2]
+        }
+
+        /**
+         * Asserts the lengths describe a usable prefix code: within [maxCodeLength], and with a
+         * Kraft sum of exactly one so the canonical assignment neither overruns nor leaves holes.
+         */
+        fun assertValidPrefixCode(lengths: IntArray, maxCodeLength: Int) {
+            var kraftNumerator = 0L
+            val scale = 1L shl maxCodeLength
+            for (length in lengths) {
+                if (length == 0) continue
+                assertTrue(length <= maxCodeLength, "code length $length exceeds $maxCodeLength")
+                kraftNumerator += scale shr length
+            }
+            assertEquals(scale, kraftNumerator, "code is not a complete prefix code")
+        }
+    }
+
+    @Test
+    fun `deeply skewed frequencies stay within the code length limit`() {
+        for (count in 2..64) {
+            val frequencies = fibonacciFrequencies(count)
+            val lengths = HuffmanTree.fromFrequencies(frequencies).codeLengths()
+            assertValidPrefixCode(lengths, HuffmanTree.MAX_CODE_LENGTH)
+        }
+    }
+
+    @Test
+    fun `code length alphabet trees stay within the three bit ceiling`() {
+        val frequencies = fibonacciFrequencies(DeflateConstants.CODE_LENGTH_ALPHABET_SIZE)
+        val lengths = HuffmanTree
+            .fromFrequencies(frequencies, DeflateConstants.MAX_CL_CODE_LENGTH)
+            .codeLengths()
+        assertValidPrefixCode(lengths, DeflateConstants.MAX_CL_CODE_LENGTH)
+    }
+
+    @Test
+    fun `limiting keeps the shortest codes on the most frequent symbols`() {
+        val frequencies = fibonacciFrequencies(40)
+        val lengths = HuffmanTree.fromFrequencies(frequencies).codeLengths()
+        // Symbol 39 is by far the most frequent, symbol 0 the rarest.
+        assertTrue(lengths[39] <= lengths[0], "frequent symbol got a longer code than a rare one")
+        assertValidPrefixCode(lengths, HuffmanTree.MAX_CODE_LENGTH)
+    }
+
+    @Test
+    fun `unskewed frequencies are left untouched`() {
+        val frequencies = IntArray(16) { 1 }
+        val lengths = HuffmanTree.fromFrequencies(frequencies).codeLengths()
+        // A balanced alphabet of 16 needs exactly four bits per symbol and no repair at all.
+        assertContentEquals(IntArray(16) { 4 }, lengths)
+    }
+
+    @Test
+    fun `symbols encode and decode through a limited tree`() {
+        val frequencies = fibonacciFrequencies(40)
+        val tree = HuffmanTree.fromFrequencies(frequencies)
+        for (symbol in frequencies.indices) {
+            val code = tree.encodingOf(symbol)
+            assertTrue(code.length in 1..HuffmanTree.MAX_CODE_LENGTH, "bad code length for $symbol")
+        }
+    }
+}

--- a/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTreeLengthLimitTest.kt
+++ b/kompress-core/src/commonTest/kotlin/dev/karmakrafts/kompress/huffman/HuffmanTreeLengthLimitTest.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,14 @@
 
 package dev.karmakrafts.kompress.huffman
 
+import dev.karmakrafts.karbide.BitOrder
+import dev.karmakrafts.karbide.bitSink
+import dev.karmakrafts.karbide.bitSource
 import dev.karmakrafts.kompress.deflate.DeflateConstants
+import dev.karmakrafts.kompress.deflate.Deflater
+import dev.karmakrafts.kompress.deflate.Inflater
+import kotlinx.io.Buffer
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -31,11 +38,46 @@ import kotlin.test.assertTrue
  */
 class HuffmanTreeLengthLimitTest {
     private companion object {
-        /** Frequencies that force the deepest possible tree: one extra level per symbol. */
-        fun fibonacciFrequencies(count: Int): IntArray = IntArray(count).apply {
-            this[0] = 1
-            if (count > 1) this[1] = 1
-            for (index in 2 until count) this[index] = this[index - 1] + this[index - 2]
+        /**
+         * The largest alphabet [fibonacciFrequencies] can describe.
+         *
+         * Frequencies grow as Fibonacci numbers and the tree builder sums them into a single [Int],
+         * so the total has to stay below [Int.MAX_VALUE]. Fib(1..44) already sums to 1836311902,
+         * and one step further overflows.
+         */
+        const val MAX_FIBONACCI_SYMBOLS: Int = 44
+
+        /**
+         * Frequencies that force the deepest possible tree: every extra symbol adds a level.
+         *
+         * [count] must not exceed [MAX_FIBONACCI_SYMBOLS], since silently wrapping into negative
+         * frequencies would drop symbols and quietly test a much shallower alphabet instead.
+         */
+        fun fibonacciFrequencies(count: Int): IntArray {
+            require(count in 2..MAX_FIBONACCI_SYMBOLS) { "Unsupported symbol count $count" }
+            return IntArray(count).apply {
+                this[0] = 1
+                this[1] = 1
+                for (index in 2 until count) this[index] = this[index - 1] + this[index - 2]
+                for (frequency in this) check(frequency > 0) { "Frequency overflowed" }
+            }
+        }
+
+        /** Bytes drawn from a Fibonacci weighted distribution, which deflates into a very deep tree. */
+        fun skewedPayload(size: Int): ByteArray {
+            val weights = fibonacciFrequencies(40)
+            var total = 0
+            for (weight in weights) total += weight
+            val random = Random(0x51DE)
+            return ByteArray(size) {
+                var remaining = random.nextInt(total)
+                var symbol = 0
+                while (symbol < weights.size - 1 && remaining >= weights[symbol]) {
+                    remaining -= weights[symbol]
+                    symbol++
+                }
+                symbol.toByte()
+            }
         }
 
         /**
@@ -56,7 +98,7 @@ class HuffmanTreeLengthLimitTest {
 
     @Test
     fun `deeply skewed frequencies stay within the code length limit`() {
-        for (count in 2..64) {
+        for (count in 2..MAX_FIBONACCI_SYMBOLS) {
             val frequencies = fibonacciFrequencies(count)
             val lengths = HuffmanTree.fromFrequencies(frequencies).codeLengths()
             assertValidPrefixCode(lengths, HuffmanTree.MAX_CODE_LENGTH)
@@ -90,12 +132,24 @@ class HuffmanTreeLengthLimitTest {
     }
 
     @Test
-    fun `symbols encode and decode through a limited tree`() {
+    fun `symbols round trip through a limited tree`() {
         val frequencies = fibonacciFrequencies(40)
         val tree = HuffmanTree.fromFrequencies(frequencies)
-        for (symbol in frequencies.indices) {
-            val code = tree.encodingOf(symbol)
-            assertTrue(code.length in 1..HuffmanTree.MAX_CODE_LENGTH, "bad code length for $symbol")
+        val buffer = Buffer()
+        buffer.bitSink(bitOrder = BitOrder.LSB_FIRST).use { sink ->
+            for (symbol in frequencies.indices) tree.encodeSymbol(sink, symbol)
         }
+        buffer.bitSource(bitOrder = BitOrder.LSB_FIRST).use { source ->
+            for (symbol in frequencies.indices) assertEquals(symbol, tree.decodeSymbol(source))
+        }
+    }
+
+    @Test
+    fun `heavily skewed data survives a deflate inflate round trip`() {
+        // Regression test for the reported symptom: a single block over enough skewed data used to
+        // need codes longer than 15 bits, producing a stream that could not be read back at all.
+        val data = skewedPayload(256 * 1024)
+        val compressed = Deflater.compress(data)
+        assertContentEquals(data, Inflater.decompress(compressed))
     }
 }


### PR DESCRIPTION
For my motivation, please read my other PR first. Again, if you don't accept AI contributions, close this directly.

The stored block handling was a degenerate case. This PR adds a benchmark for it and speeds it up by about 38x. Overall, this should slightly beat zlib.

This includes the commits from the previous PR. If you want them separated, let me know.