### PR TITLE
Fix ZipGPBF boolean constructor dropping flags after first true condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- `ZipGPBF`'s boolean-parameter constructor silently dropping every flag after the first `true` condition, due to an unparenthesized `if`/`else` chain inside an `or` expression (each `else` branch greedily absorbed the rest of the chain). In particular, the common case of only the two `true`-by-default parameters (`omitChecksumAndSizes`, `languageEncoding`) — e.g. a bare `ZipGPBF()` — produced a value with `LANGUAGE_ENCODING` missing entirely.
+
 ## [2.3.1]
 
 ### Fixed

--- a/kompress-zip/src/commonMain/kotlin/dev/karmakrafts/kompress/zip/ZipGPBF.kt
+++ b/kompress-zip/src/commonMain/kotlin/dev/karmakrafts/kompress/zip/ZipGPBF.kt
@@ -73,11 +73,11 @@ value class ZipGPBF(val value: UShort) {
         languageEncoding: Boolean = true,
         maskedHeaderValues: Boolean = false
     ) : this( // @formatter:off
-        if(omitChecksumAndSizes) OMIT_CHECKSUM_AND_SIZES else 0U.toUShort()
-            or if(isPatchedData) PATCHED_DATA else 0U.toUShort()
-            or if(hasStrongEncryption) STRONG_ENCRYPTION else 0U.toUShort()
-            or if(languageEncoding) LANGUAGE_ENCODING else 0U.toUShort()
-            or if(maskedHeaderValues) MASKED_HEADER_VALUES else 0U.toUShort()
+        (if(omitChecksumAndSizes) OMIT_CHECKSUM_AND_SIZES else 0U.toUShort())
+            or (if(isPatchedData) PATCHED_DATA else 0U.toUShort())
+            or (if(hasStrongEncryption) STRONG_ENCRYPTION else 0U.toUShort())
+            or (if(languageEncoding) LANGUAGE_ENCODING else 0U.toUShort())
+            or (if(maskedHeaderValues) MASKED_HEADER_VALUES else 0U.toUShort())
     ) // @formatter:on
 
     /**

--- a/kompress-zip/src/commonTest/kotlin/dev/karmakrafts/kompress/zip/ZipGPBFTest.kt
+++ b/kompress-zip/src/commonTest/kotlin/dev/karmakrafts/kompress/zip/ZipGPBFTest.kt
@@ -43,6 +43,27 @@ class ZipGPBFTest {
     }
 
     @Test
+    fun `Boolean constructor combines multiple true flags`() {
+        // Regression test: chaining `if(a) A else 0 or if(b) B else 0 or ...` without parentheses
+        // let each `else` branch swallow the rest of the `or` chain — so whenever the *first*
+        // condition was true, every subsequent flag was silently dropped instead of combined.
+        val gpbf = ZipGPBF(omitChecksumAndSizes = true, languageEncoding = true)
+
+        assertEquals(ZipGPBF.OMIT_CHECKSUM_AND_SIZES or ZipGPBF.LANGUAGE_ENCODING, gpbf.value)
+        assertTrue(gpbf.omitChecksumAndSizes)
+        assertTrue(gpbf.languageEncoding)
+    }
+
+    @Test
+    fun `Boolean constructor defaults combine omitChecksumAndSizes and languageEncoding`() {
+        // Both boolean parameter defaults are `true` — this is what a bare `ZipGPBF()` produces,
+        // and exactly the case the bug above silently broke (dropped LANGUAGE_ENCODING).
+        val gpbf = ZipGPBF()
+
+        assertEquals(ZipGPBF.OMIT_CHECKSUM_AND_SIZES or ZipGPBF.LANGUAGE_ENCODING, gpbf.value)
+    }
+
+    @Test
     fun `Raw mask accessors expose all GPBF bits`() {
         val gpbf = ZipGPBF(ZipGPBF.STRONG_ENCRYPTION or ZipGPBF.LANGUAGE_ENCODING)
 


### PR DESCRIPTION
The boolean-parameter constructor built its UShort value as:

    if(a) A else 0 or if(b) B else 0 or if(c) C else 0 or ...

Kotlin's if/else is an expression, and each else branch here greedily absorbed the rest of the or chain instead of being one term in a flat sequence of ORs. So whenever the *first* condition (omitChecksumAndSizes, true by default) was true, its then-branch (just OMIT_CHECKSUM_AND_SIZES) became the value of the *entire* expression, and every subsequent condition/or was silently unreachable.

Concretely, a bare ZipGPBF() (both boolean defaults true) produced only OMIT_CHECKSUM_AND_SIZES, dropping LANGUAGE_ENCODING entirely.

Fix: parenthesize each if/else term so or is applied between five complete terms, matching the original intent.

Added two regression tests covering exactly the case the existing test suite missed (the existing test happened to set omitChecksumAndSizes = false, which routes through the else branch and doesn't trigger the bug). Verified both new tests fail on the pre-fix source and pass after the fix, on kompress-zip:jsNodeTest and kompress-zip:mingwX64Test.